### PR TITLE
Fix pip package name

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ To install:
 
 .. code-block:: bash
 
-    pip install agatestats
+    pip install agate-stats
 
 For details on development or supported platforms see the `agate documentation <http://agate.readthedocs.org>`_.
 


### PR DESCRIPTION
Apply fix to pip package name in doc's index file from agatestats to the correct agate-stats
